### PR TITLE
DRAFT: Increase required zoom level for rail/metro stops 

### DIFF
--- a/src/components/addLayers/addStops.ts
+++ b/src/components/addLayers/addStops.ts
@@ -136,7 +136,7 @@ export function addStopsLayers(map:any, darkMode:boolean, layerspercategory:any)
             ],
             ['!',['in', 2, ['get', "children_route_types"]]]
         ],
-        minzoom: 9
+        minzoom: 10
     });
 
     //INTERCITY RAIL
@@ -157,7 +157,7 @@ export function addStopsLayers(map:any, darkMode:boolean, layerspercategory:any)
         'circle-stroke-opacity': ['step', ['zoom'], 0.5, 15, 0.6],
         'circle-opacity': 0.1
     },
-    minzoom: 5,
+    minzoom: 7,
     filter: removeWeekendStops(['all',
     [
         'all',
@@ -182,7 +182,7 @@ map.addLayer({
     layout: {
         'text-field': ['get', 'displayname'],
         'text-variable-anchor': ['left', 'right', 'top', 'bottom'],
-        'text-size': window.innerWidth >= 1023 ? ['interpolate', ['linear'], ['zoom'], 9, 10, 15, 12, 17, 14] : ['interpolate', ['linear'], ['zoom'], 9, 8, 15, 10, 17, 12],
+        'text-size': window.innerWidth >= 1023 ? ['interpolate', ['linear'], ['zoom'], 6, 8, 9, 10, 15, 12, 17, 14] : ['interpolate', ['linear'], ['zoom'], 9, 8, 15, 10, 17, 12],
         'text-radial-offset': 1,
         //'text-ignore-placement': true,
         //'icon-ignore-placement': false,
@@ -210,7 +210,7 @@ map.addLayer({
         ['in', 2, ['get', "children_route_types"]]
         ]
     ],
-    minzoom: 5
+    minzoom: 7
 });
 
    //OTHER


### PR DESCRIPTION
Hello @samuelbeepdev and team!

This pull request was mainly created due to the growth of data Catenary supports in the European Union.

Currently, the software attempts to load in an excessive amount of rail stops for all of Germany.
![image](https://github.com/CatenaryTransit/catenary-frontend/assets/7539174/60e21bf7-bda1-45ba-9c27-c25b8f995ce3)

Now, intercity rail stops don't load in until level 7.
![image](https://github.com/CatenaryTransit/catenary-frontend/assets/7539174/28170617-a67f-4c69-9388-230de74e026b)

However, this level presents quite the bloat! Perhaps we should work on a method to cull non-important rail stops at this resolution and to fix the bug preventing the reduction of duplicate stops.  That involves some backend and stop analysis work.

I am especially inspired by the amazing work done by NYC MTA, with their map, https://radar.mta.info/, in which major junctions are labelled and non-major terminals are culled until a certain zoom level.

![image](https://github.com/CatenaryTransit/catenary-frontend/assets/7539174/daf7bec9-279b-4584-b2da-03d282904fda)
![image](https://github.com/CatenaryTransit/catenary-frontend/assets/7539174/cced382b-b0ff-421e-9355-b7bbc0c64326)

Cheerio,
Kyler
